### PR TITLE
Emergency Fix

### DIFF
--- a/qr.py
+++ b/qr.py
@@ -238,12 +238,10 @@ class PriorityQueue(BaseQueue):
     
     def dump(self, fobj):
         """Destructively dump the contents of the queue into fp"""
-        next = self.redis.zrange(self.key, 0, 0, withscores=True)
-        removed = self.redis.zremrangebyrank(self.key, 0, 0)
+        next = self.pop()
         while next:
             self.serializer.dump(next[0], fobj)
-            next = self.redis.zrange(self.key, 0, 0, withscores=True)
-            removed = self.redis.zremrangebyrank(self.key, 0, 0)
+            next = self.pop()
     
     def load(self, fobj):
         """Load the contents of the provided fobj into the queue"""


### PR DESCRIPTION
Hey again,

Turns out through much hair-pulling-and-face-palming I discovered that the PriorityQueue I wrote did not have atomic pops. D'oh! We discovered this when we had two processes running and using a shared PriorityQueue and they were very occasionally pulling off the same key.

This pull request includes the fix to make the PriorityQueue pop atomic, along with some initial thinking I'm doing on having a `worker` decorator. If you'd prefer, I can remove the co-mingling of the two changes.

Sorry for the bug, but we just discovered it yesterday after several days of teeth-gnashing :-(
